### PR TITLE
Fix: Handle nested premature NJK template content errors

### DIFF
--- a/src/Errors/ErrorUtil.js
+++ b/src/Errors/ErrorUtil.js
@@ -57,6 +57,7 @@ export default class ErrorUtil {
 	}
 
 	static isPrematureTemplateContentError(e) {
+		let rootError = e;
 		let pending = [e];
 		let seen = new Set();
 
@@ -71,7 +72,8 @@ export default class ErrorUtil {
 
 			if (
 				error instanceof TemplateContentPrematureUseError ||
-				error?.message?.includes("TemplateContentPrematureUseError")
+				// Preserve the legacy Nunjucks fallback without matching unrelated nested messages.
+				(error === rootError && error?.message?.includes("TemplateContentPrematureUseError"))
 			) {
 				return true;
 			}
@@ -80,7 +82,7 @@ export default class ErrorUtil {
 				pending.push(error.cause);
 			}
 
-			// Liquid uses originalError.originalError instead of Error.cause.
+			// Liquid requires this guarded non-standard path instead of Error.cause.
 			if (
 				["RenderError", "UndefinedVariableError"].includes(error?.originalError?.name) &&
 				error?.originalError?.originalError

--- a/src/Errors/ErrorUtil.js
+++ b/src/Errors/ErrorUtil.js
@@ -57,13 +57,38 @@ export default class ErrorUtil {
 	}
 
 	static isPrematureTemplateContentError(e) {
-		// TODO the rest of the template engines
-		return (
-			e instanceof TemplateContentPrematureUseError ||
-			e?.cause instanceof TemplateContentPrematureUseError || // Custom (per Node-convention)
-			(["RenderError", "UndefinedVariableError"].includes(e?.originalError?.name) &&
-				e?.originalError?.originalError instanceof TemplateContentPrematureUseError) || // Liquid
-			e?.message?.includes("TemplateContentPrematureUseError") // Nunjucks
-		);
+		let pending = [e];
+		let seen = new Set();
+
+		while (pending.length > 0) {
+			let error = pending.pop();
+
+			if (!error || seen.has(error)) {
+				continue;
+			}
+
+			seen.add(error);
+
+			if (
+				error instanceof TemplateContentPrematureUseError ||
+				error?.message?.includes("TemplateContentPrematureUseError")
+			) {
+				return true;
+			}
+
+			if (error.cause) {
+				pending.push(error.cause);
+			}
+
+			// Liquid uses originalError.originalError instead of Error.cause.
+			if (
+				["RenderError", "UndefinedVariableError"].includes(error?.originalError?.name) &&
+				error?.originalError?.originalError
+			) {
+				pending.push(error.originalError.originalError);
+			}
+		}
+
+		return false;
 	}
 }

--- a/test/ErrorUtilTest.js
+++ b/test/ErrorUtilTest.js
@@ -1,5 +1,6 @@
 import test from "ava";
 import ErrorUtil from "../src/Errors/ErrorUtil.js";
+import TemplateContentPrematureUseError from "../src/Errors/TemplateContentPrematureUseError.js";
 
 const SAMPLE_ERROR = new Error("Nothing to see here");
 
@@ -46,4 +47,21 @@ test("deconvertErrorToObject() should get message and stack from convertErrorToS
   t.is(result.name, nestingError.name);
   t.is(result.message, SAMPLE_ERROR.message);
   t.is(result.stack, SAMPLE_ERROR.stack);
+});
+
+test("isPrematureTemplateContentError() follows nested Error.cause values", (t) => {
+  let prematureError = new TemplateContentPrematureUseError("Too early");
+  let error = new Error("Outer error", {
+    cause: new Error("Inner error", { cause: prematureError }),
+  });
+
+  t.true(ErrorUtil.isPrematureTemplateContentError(error));
+});
+
+test("isPrematureTemplateContentError() ignores matching text in nested errors", (t) => {
+  let error = new Error("Outer error", {
+    cause: new Error("Documentation mentions TemplateContentPrematureUseError"),
+  });
+
+  t.false(ErrorUtil.isPrematureTemplateContentError(error));
 });

--- a/test/TemplateTest.js
+++ b/test/TemplateTest.js
@@ -1489,6 +1489,50 @@ test("Throws a Premature Template Content Error from rendering (njk)", async (t)
   t.is(ErrorUtil.isPrematureTemplateContentError(error), true);
 });
 
+test("Recognizes a Premature Template Content Error wrapped by a Nunjucks filter", async (t) => {
+  let eleventyConfig = await getTemplateConfigInstanceCustomCallback({}, function (cfg) {
+    cfg.addFilter("renderedContent", (items) => items[0].templateContent);
+  });
+  let tmpl = await getNewTemplate(
+    "./test/stubs/prematureTemplateContent/filter.njk",
+    "./test/stubs/",
+    "./test/stubs/_site",
+    null,
+    null,
+    eleventyConfig
+  );
+
+  let data = await tmpl.getData();
+  await tmpl.getTemplateMapEntry(data);
+
+  let pageEntries = await tmpl.getTemplates({
+    page: {},
+    samples: [
+      {
+        get templateContent() {
+          throw new TemplateContentPrematureUseError(
+            "Tried to use templateContent too early (filter.njk)"
+          );
+        },
+      },
+    ],
+  });
+  let error = await t.throwsAsync(async () => {
+    await tmpl.renderPageEntry(pageEntries[0]);
+  });
+
+  t.is(ErrorUtil.isPrematureTemplateContentError(error), true);
+});
+
+test("Premature Template Content Error detection handles cycles", (t) => {
+  let error = new Error("Outer error");
+  let cause = new Error("Inner error");
+  error.cause = cause;
+  cause.cause = error;
+
+  t.is(ErrorUtil.isPrematureTemplateContentError(error), false);
+});
+
 test("Throws a Premature Template Content Error (liquid)", async (t) => {
   let tmpl = await getNewTemplate(
     "./test/stubs/prematureTemplateContent/test.liquid",

--- a/test/stubs/prematureTemplateContent/filter.njk
+++ b/test/stubs/prematureTemplateContent/filter.njk
@@ -1,0 +1,1 @@
+{{ samples | renderedContent }}


### PR DESCRIPTION
tl;dr: This adds better error handling in the new v4 NJK template rendering + tests.

In Eleventy 4.0.0-alpha.10 with `@11ty/nunjucks` 4.0.0-alpha.3, a `TemplateContentPrematureUseError` thrown inside a Nunjucks filter can be wrapped in more than one `Error.cause` layer. Eleventy uses that error as a signal that a template has asked for another template’s rendered content too early: it normally catches the signal, renders the dependency, and tries again. Once Nunjucks has wrapped the error several layers deep, Eleventy no longer recognizes it and stops the build instead of retrying.

Conceptually, the error changes from this:

```text
TemplateContentPrematureUseError
```

to something like this:

```text
Nunjucks render error
└── Nunjucks filter error
    └── TemplateContentPrematureUseError
```

The existing check recognizes the original error and one `Error.cause` wrapper, but not the additional nesting. This change recursively checks the recognized wrapper paths until it finds the original retry signal.

Conceptually, the check changes from this:

```text
Is this the retry signal?
If not, is its immediate cause the retry signal?
```

to this:

```text
Start with the outer error.
Check whether it is the retry signal.
Follow its standard Error.cause link and repeat.
At each level, also retain Eleventy’s guarded Liquid error path.
Stop when the signal is found or all recognized paths have been checked.
```

This allows any number of normal `Error.cause` wrappers while the repeated-error check prevents an accidental cycle from looping forever. It does not treat every arbitrary `originalError` property as a wrapper.

## Reproduction

Minimal reproduction: <https://github.com/khawkins98/eleventy-v4-template-content-repro>

The reproduction uses a synchronous Nunjucks filter that reads `templateContent` from a tagged collection:

- Unpatched Eleventy 4.0.0-alpha.10 fails with a wrapped `TemplateContentPrematureUseError`.
- Catching the error defensively makes the build pass but incorrectly renders `0`.
- Applying this change to the public reproduction allows Eleventy’s normal retry path to complete, producing the expected result, `6`.

## Implementation

`ErrorUtil.isPrematureTemplateContentError()` now walks nested `Error.cause` values with cycle protection.

The existing guarded Liquid `originalError.originalError` path remains restricted to `RenderError` and `UndefinedVariableError`; the same guarded check is now available beneath standard `Error.cause` wrappers. The implementation does not follow arbitrary `originalError` properties.

This extends the approach previously accepted in #3651, which added support for one level of `Error.cause` while retaining the Liquid guards.

## Tests

- Added a regression test confirming that `ErrorUtil` recognizes a `TemplateContentPrematureUseError` after it passes through a Nunjucks filter.
- Added coverage for cyclic `Error.cause` graphs.
- `npm run test:server`: 1,438 passed, 28 skipped.
- `npm run check`: no errors; 25 pre-existing warnings.

## Alternatives

The Nunjucks integration could instead preserve the original retry signal at its wrapping boundary. I used recursive detection here because Eleventy already centralizes template-engine-specific recognition in `ErrorUtil`, and #3651 established `Error.cause` handling there. I am happy to adjust this if a fix in `@11ty/nunjucks` is preferred.

## Disclaimer

AI assistance was used to help reduce and test the reproduction and prepare this change.
